### PR TITLE
Add Common Alpine Utilities

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,9 +11,10 @@
       "userUid": "automatic",
       "userGid": "automatic",
       "nonFreePackages": false
-    }
+    },
+    "ghcr.io/paschalcs/pardus-features/common-alpine:latest": {}
   },
-  "containerUser": "root",
+  "containerUser": "panther",
   "customizations": {
     "codespaces": {},
     "vscode": {


### PR DESCRIPTION
The default container image does not have a means to install packages via apk. This is a step in that direction.